### PR TITLE
feat [CP-4035] - Upgrade to MySQL 8.0 and address incompatibility issues with MySQL 5.7

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ Release Notes
         * User Management
             * [CP-4069] - Add API to fetch user details by username
             * [CP-4069] - Improvement on update user and role
+        * Database
+            * [CP-4035] - Upgrade to MySQL 8.0 and address incompatibility issues with MySQL 5.7
 
 ## Version 1.1.12 - Up to date with Mifos Version 1.5.0
     * Payment Hub OPs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   operations-mysql:
-    image: mysql:5.7
+    image: mysql:8.0
     restart: always
     volumes:
       - /home/docker/data/mysql:/var/lib/mysql

--- a/src/main/java/org/apache/fineract/core/service/TenantDatabaseUpgradeService.java
+++ b/src/main/java/org/apache/fineract/core/service/TenantDatabaseUpgradeService.java
@@ -81,6 +81,9 @@ public class TenantDatabaseUpgradeService {
     @Value("${token.client.channel.secret}")
     private String channelClientSecret;
 
+    @Value("${fineract.flyway.repair-on-startup:false}")
+    private boolean flywayRepairOnStartup;
+
     @Value("#{'${tenants}'.split(',')}")
     private List<String> tenants;
 
@@ -111,6 +114,10 @@ public class TenantDatabaseUpgradeService {
                     placeholders.put("channelClientSecret", channelClientSecret);
                     placeholders.put("identityProviderResourceId", "identity-provider"); // add identity provider as aud claim
                     fw.setPlaceholders(placeholders);
+                    if (flywayRepairOnStartup) {
+                        fw.repair();
+                        logger.warn("Flyway repair executed for tenant: {}", tenant.getSchemaName());
+                    }
                     fw.migrate();
                 } catch (Exception e) {
                     logger.error("Error when running flyway on tenant: {}", tenant.getSchemaName(), e);

--- a/src/main/java/org/apache/fineract/organisation/permission/Permission.java
+++ b/src/main/java/org/apache/fineract/organisation/permission/Permission.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.organisation.permission;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.fineract.config.CustomAuditingEntityListener;
 import org.apache.fineract.organisation.parent.AbstractPersistableCustom;
 import org.apache.fineract.organisation.role.Role;
@@ -38,8 +39,9 @@ import java.util.Objects;
 @EntityListeners(CustomAuditingEntityListener.class)
 public class Permission extends AbstractPersistableCustom<Long> {
 
-    @Column(name = "`grouping`", nullable = false, length = 45)
-    private String grouping;
+    @Column(name = "module", nullable = false, length = 45)
+    @JsonProperty("grouping")
+    private String module;
 
     @Column(name = "code", nullable = false, length = 100)
     private String code;
@@ -68,12 +70,12 @@ public class Permission extends AbstractPersistableCustom<Long> {
         this.roles = roles;
     }
 
-    public String getGrouping() {
-        return grouping;
+    public String getModule() {
+        return module;
     }
 
-    public void setGrouping(String grouping) {
-        this.grouping = grouping;
+    public void setModule(String module) {
+        this.module = module;
     }
 
     public String getCode() {

--- a/src/main/java/org/apache/fineract/organisation/permission/Permission.java
+++ b/src/main/java/org/apache/fineract/organisation/permission/Permission.java
@@ -38,7 +38,7 @@ import java.util.Objects;
 @EntityListeners(CustomAuditingEntityListener.class)
 public class Permission extends AbstractPersistableCustom<Long> {
 
-    @Column(name = "grouping", nullable = false, length = 45)
+    @Column(name = "`grouping`", nullable = false, length = 45)
     private String grouping;
 
     @Column(name = "code", nullable = false, length = 100)

--- a/src/main/java/org/apache/fineract/organisation/permission/PermissionData.java
+++ b/src/main/java/org/apache/fineract/organisation/permission/PermissionData.java
@@ -18,13 +18,16 @@
  */
 package org.apache.fineract.organisation.permission;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Immutable representation of permissions
  */
 public class PermissionData {
 
     @SuppressWarnings("unused")
-    private String grouping;
+    @JsonProperty("grouping")
+    private String module;
     @SuppressWarnings("unused")
     private String code;
     @SuppressWarnings("unused")
@@ -34,12 +37,12 @@ public class PermissionData {
     @SuppressWarnings("unused")
     private Boolean selected;
 
-    public String getGrouping() {
-        return grouping;
+    public String getModule() {
+        return module;
     }
 
-    public void setGrouping(String grouping) {
-        this.grouping = grouping;
+    public void setModule(String module) {
+        this.module = module;
     }
 
     public String getCode() {
@@ -80,14 +83,14 @@ public class PermissionData {
         return new PermissionData(null, permissionCode, null, null, isSelected);
     }
 
-    public static PermissionData instance(final String grouping, final String code, final String entityName, final String actionName,
+    public static PermissionData instance(final String module, final String code, final String entityName, final String actionName,
             final Boolean selected) {
-        return new PermissionData(grouping, code, entityName, actionName, selected);
+        return new PermissionData(module, code, entityName, actionName, selected);
     }
 
-    public PermissionData(final String grouping, final String code, final String entityName, final String actionName,
+    public PermissionData(final String module, final String code, final String entityName, final String actionName,
             final Boolean selected) {
-        this.grouping = grouping;
+        this.module = module;
         this.code = code;
         this.entityName = entityName;
         this.actionName = actionName;

--- a/src/main/java/org/apache/fineract/organisation/permission/PermissionRepository.java
+++ b/src/main/java/org/apache/fineract/organisation/permission/PermissionRepository.java
@@ -35,9 +35,9 @@ public interface PermissionRepository extends JpaRepository<Permission, Long> {
     @Query("SELECT DISTINCT p.actionName FROM Permission p")
     List<String> findDistinctActionNames();
     
-    @Query("SELECT new org.apache.fineract.organisation.permission.PermissionData(p.grouping, p.code, p.entityName, p.actionName, " +
+    @Query("SELECT new org.apache.fineract.organisation.permission.PermissionData(p.module, p.code, p.entityName, p.actionName, " +
            "CASE WHEN EXISTS (SELECT 1 FROM Role r JOIN r.permissions rp WHERE r.id = :roleId AND rp.id = p.id) THEN true ELSE false END) " +
            "FROM Permission p " +
-           "ORDER BY p.grouping, p.code")
+           "ORDER BY p.module, p.code")
     List<PermissionData> findAllPermissionsWithRoleSelection(@Param("roleId") Long roleId);
 }

--- a/src/main/resources/application-keycloak.yml
+++ b/src/main/resources/application-keycloak.yml
@@ -71,7 +71,7 @@ rest:
         authority: "hasAuthority('ALL_FUNCTIONS')"
 logging:
   level:
-    ROOT: ERROR
+    ROOT: INFO
     pattern:
       console: "%clr(%d{dd-MM-yyyy HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([%35.35t]){faint} %clr(%-28.28logger{28}){cyan} %clr(:){faint}%X{BUSINESS-LOG} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,8 @@ fineract:
       protocol: jdbc
       subprotocol: mysql
       driverclass_name: com.mysql.cj.jdbc.Driver
+  flyway:
+    repair-on-startup: false
 
 # Interface time zone reference : https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 interface:

--- a/src/main/resources/sql/migrations/core/V5__mysql8_compatibility_utf8mb4.sql
+++ b/src/main/resources/sql/migrations/core/V5__mysql8_compatibility_utf8mb4.sql
@@ -1,0 +1,4 @@
+--
+-- MySQL 8.0 Compatibility: Convert core tenants table from utf8 to utf8mb4
+--
+ALTER TABLE `tenant_server_connections` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;

--- a/src/main/resources/sql/migrations/tenant/V22__password_validation_policy.sql
+++ b/src/main/resources/sql/migrations/tenant/V22__password_validation_policy.sql
@@ -27,35 +27,37 @@ CREATE TABLE IF NOT EXISTS `m_password_validation_policy` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
 
 
-INSERT INTO `m_password_validation_policy` (
-`id` ,
-`regex` ,
-`description` ,
-`active`
-)
-VALUES (
-NULL ,  '^.{1,50}$',  'Password most be at least 1 character and not more that 50 characters long',  '1'
+INSERT INTO `m_password_validation_policy` (`regex`, `description`, `active`)
+SELECT '^.{1,50}$', 'Password most be at least 1 character and not more that 50 characters long', '1'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `m_password_validation_policy` WHERE `regex` = '^.{1,50}$'
 );
 
-INSERT INTO `m_password_validation_policy` (
-`id` ,
-`regex` ,
-`description` ,
-`active`
-)
-VALUES (
-NULL ,  '^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\\s).{6,50}$',  'Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space',  '0'
+INSERT INTO `m_password_validation_policy` (`regex`, `description`, `active`)
+SELECT '^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\\s).{6,50}$',
+       'Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space',
+       '0'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `m_password_validation_policy` WHERE `regex` = '^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\\s).{6,50}$'
 );
 
-INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
-VALUE ("authorisation","READ_PASSWORD_PREFERENCES","PASSWORD_PREFERENCES","READ",0);
+INSERT INTO `m_permission` (`grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`)
+SELECT 'authorisation', 'READ_PASSWORD_PREFERENCES', 'PASSWORD_PREFERENCES', 'READ', 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM `m_permission` WHERE `code` = 'READ_PASSWORD_PREFERENCES'
+);
 
-INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
-VALUE ("authorisation","UPDATE_PASSWORD_PREFERENCES","PASSWORD_PREFERENCES","UPDATE",0);
+INSERT INTO `m_permission` (`grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`)
+SELECT 'authorisation', 'UPDATE_PASSWORD_PREFERENCES', 'PASSWORD_PREFERENCES', 'UPDATE', 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM `m_permission` WHERE `code` = 'UPDATE_PASSWORD_PREFERENCES'
+);
 
-INSERT INTO m_permission (grouping, code, entity_name, action_name, can_maker_checker)
-VALUE ("authorisation","UPDATE_PASSWORD_PREFERENCES_CHECKER","PASSWORD_PREFERENCES","UPDATE_CHECKER",0);
-
+INSERT INTO `m_permission` (`grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`)
+SELECT 'authorisation', 'UPDATE_PASSWORD_PREFERENCES_CHECKER', 'PASSWORD_PREFERENCES', 'UPDATE_CHECKER', 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM `m_permission` WHERE `code` = 'UPDATE_PASSWORD_PREFERENCES_CHECKER'
+);
 
 
 

--- a/src/main/resources/sql/migrations/tenant/V47__Add_permissions_for_resources.sql
+++ b/src/main/resources/sql/migrations/tenant/V47__Add_permissions_for_resources.sql
@@ -1,36 +1,36 @@
 update m_permission
-set code = 'READ_TRANSFER', grouping = 'transfers', entity_name = 'TRANSFER', action_name = 'READ'
-where code = 'REFUND' and grouping = 'operations';
+set code = 'READ_TRANSFER', `grouping` = 'transfers', entity_name = 'TRANSFER', action_name = 'READ'
+where code = 'REFUND' and `grouping` = 'operations';
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('CREATE_TRANSFER', 'transfers', 'TRANSFER', 'CREATE', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('EXPORT_TRANSFER', 'transfers', 'TRANSFER', 'EXPORT', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('READ_USER', 'authorisation', 'USER', 'READ', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('CREATE_USER', 'authorisation', 'USER', 'CREATE', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('UPDATE_USER', 'authorisation', 'USER', 'UPDATE', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('SUSPEND_USER', 'authorisation', 'USER', 'SUSPEND', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('ACTIVATE_USER', 'authorisation', 'USER', 'ACTIVATE', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('DELETE_USER', 'authorisation', 'USER', 'DELETE', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('READ_AUDIT', 'audit', 'AUDIT', 'READ', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('EXPORT_TRANSACTION_REQUEST', 'transactionRequests', 'TRANSACTION_REQUEST', 'EXPORT', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('READ_TRANSACTION_REQUEST', 'transactionRequests', 'TRANSACTION_REQUEST', 'READ', 0);

--- a/src/main/resources/sql/migrations/tenant/V48__Add_permissions_for_roles.sql
+++ b/src/main/resources/sql/migrations/tenant/V48__Add_permissions_for_roles.sql
@@ -1,11 +1,11 @@
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('READ_ROLE', 'authorisation', 'ROLE', 'READ', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('CREATE_ROLE', 'authorisation', 'ROLE', 'CREATE', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('UPDATE_ROLE', 'authorisation', 'ROLE', 'UPDATE', 0);
 
-insert into m_permission (code, grouping, entity_name, action_name, can_maker_checker)
+insert into m_permission (code, `grouping`, entity_name, action_name, can_maker_checker)
 values ('DELETE_ROLE', 'authorisation', 'ROLE', 'DELETE', 0);

--- a/src/main/resources/sql/migrations/tenant/V49__mysql8_compatibility_utf8mb4_and_reserved_keywords.sql
+++ b/src/main/resources/sql/migrations/tenant/V49__mysql8_compatibility_utf8mb4_and_reserved_keywords.sql
@@ -1,8 +1,13 @@
 --
 -- MySQL 8.0 Compatibility Migration
 -- 1. Convert all tables from utf8/utf8mb3 to utf8mb4 for full Unicode support
--- 2. Escape 'grouping' column name with backticks (reserved keyword in MySQL 8.0)
+-- 2. Rename 'grouping' column to 'module' (grouping is a reserved keyword in MySQL 8.0)
 --
+
+-- ============================================================
+-- ISSUE 2: Rename 'grouping' column to 'module' (reserved keyword in MySQL 8.0)
+-- ============================================================
+ALTER TABLE `m_permission` CHANGE COLUMN `grouping` `module` VARCHAR(45) NOT NULL;
 
 -- ============================================================
 -- ISSUE 1: Convert charset from utf8 (utf8mb3) to utf8mb4

--- a/src/main/resources/sql/migrations/tenant/V49__mysql8_compatibility_utf8mb4_and_reserved_keywords.sql
+++ b/src/main/resources/sql/migrations/tenant/V49__mysql8_compatibility_utf8mb4_and_reserved_keywords.sql
@@ -1,0 +1,49 @@
+--
+-- MySQL 8.0 Compatibility Migration
+-- 1. Convert all tables from utf8/utf8mb3 to utf8mb4 for full Unicode support
+-- 2. Escape 'grouping' column name with backticks (reserved keyword in MySQL 8.0)
+--
+
+-- ============================================================
+-- ISSUE 1: Convert charset from utf8 (utf8mb3) to utf8mb4
+-- ============================================================
+
+-- Core tables from V2
+ALTER TABLE `m_code` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_code_value` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_document` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_office` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_permission` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_role` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_role_permission` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_appuser` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_appuser_role` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_staff` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_group_level` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_group` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- V10: m_image
+ALTER TABLE `m_image` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- V11: m_group_roles
+ALTER TABLE `m_group_roles` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- V22: m_password_validation_policy
+ALTER TABLE `m_password_validation_policy` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- V24: oauth_client_details
+ALTER TABLE `oauth_client_details` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- Remaining tables that may have inherited the database default charset
+ALTER TABLE `m_appuser_previous_password` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_audit_source` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_beneficiary` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_currency_rates` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `m_currency_rates_lock` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `transfers` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `transaction_requests` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `tasks` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `variables` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `batches` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `businesskeys` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE `errorcode` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;

--- a/src/test/java/org/apache/fineract/test/FlywayRepairMigrationTest.java
+++ b/src/test/java/org/apache/fineract/test/FlywayRepairMigrationTest.java
@@ -1,0 +1,156 @@
+package org.apache.fineract.test;
+
+import com.googlecode.flyway.core.Flyway;
+import org.apache.fineract.core.service.DataSourcePerTenantService;
+import org.apache.fineract.core.service.TenantDatabaseUpgradeService;
+import org.apache.fineract.organisation.tenant.TenantServerConnection;
+import org.apache.fineract.organisation.tenant.TenantServerConnectionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the MySQL 8.0 upgrade change: {@code fw.repair()} is conditionally
+ * called before {@code fw.migrate()} in the tenant Flyway migration flow,
+ * controlled by the {@code fineract.flyway.repair-on-startup} property.
+ * <p>
+ * This is needed because migration files V22, V47, and V48 were modified
+ * (backtick-escaping the 'grouping' keyword), which changes their Flyway
+ * checksums. {@code repair()} updates stored checksums to match, preventing
+ * checksum mismatch errors on existing databases.
+ */
+class FlywayRepairMigrationTest {
+
+    private TenantDatabaseUpgradeService service;
+    private TenantServerConnectionRepository repository;
+    private Connection mockConn;
+    private Statement mockStmt;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        service = Mockito.spy(new TenantDatabaseUpgradeService());
+
+        repository = mock(TenantServerConnectionRepository.class);
+        DataSourcePerTenantService dataSourcePerTenantService = mock(DataSourcePerTenantService.class);
+        DataSource dataSource = mock(DataSource.class);
+        mockConn = mock(Connection.class);
+        mockStmt = mock(Statement.class);
+
+        ReflectionTestUtils.setField(service, "repository", repository);
+        ReflectionTestUtils.setField(service, "dataSourcePerTenantService", dataSourcePerTenantService);
+        ReflectionTestUtils.setField(service, "hostname", "localhost");
+        ReflectionTestUtils.setField(service, "port", 3306);
+        ReflectionTestUtils.setField(service, "username", "root");
+        ReflectionTestUtils.setField(service, "password", "pass");
+        ReflectionTestUtils.setField(service, "jdbcProtocol", "jdbc");
+        ReflectionTestUtils.setField(service, "jdbcSubprotocol", "mysql");
+        ReflectionTestUtils.setField(service, "driverClass", "com.mysql.cj.jdbc.Driver");
+        ReflectionTestUtils.setField(service, "userTokenAccessValiditySeconds", "600");
+        ReflectionTestUtils.setField(service, "userTokenRefreshValiditySeconds", "43200");
+        ReflectionTestUtils.setField(service, "clientAccessTokenValidity", "3600");
+        ReflectionTestUtils.setField(service, "channelClientSecret", "secret");
+        ReflectionTestUtils.setField(service, "flywayRepairOnStartup", true);
+        ReflectionTestUtils.setField(service, "tenants", Arrays.asList("oaf"));
+
+        when(dataSourcePerTenantService.retrieveDataSource()).thenReturn(dataSource);
+        when(mockConn.createStatement()).thenReturn(mockStmt);
+        Mockito.doReturn(mockConn)
+                .when(service)
+                .createConnection(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    @DisplayName("repair() is called before migrate() when flywayRepairOnStartup is true")
+    void shouldCallRepairBeforeMigrate() throws Exception {
+        // Arrange
+        TenantServerConnection tenant = new TenantServerConnection();
+        tenant.setSchemaName("oaf");
+        tenant.setAutoUpdateEnabled(true);
+        when(repository.findAll()).thenReturn(Collections.singletonList(tenant));
+        when(repository.findOneBySchemaName("oaf")).thenReturn(tenant);
+        when(mockStmt.executeUpdate(Mockito.anyString())).thenReturn(1);
+
+        // Act
+        try (MockedConstruction<Flyway> flywayMock = Mockito.mockConstruction(Flyway.class, (mock, ctx) ->
+            when(mock.migrate()).thenReturn(0)
+        )) {
+            service.setupEnvironment();
+
+            assertEquals(2, flywayMock.constructed().size(),
+                    "Expected 2 Flyway instances: one for core schema, one for tenant");
+
+            Flyway tenantFlyway = flywayMock.constructed().get(1);
+            verify(tenantFlyway, times(1)).repair();
+            verify(tenantFlyway, times(1)).migrate();
+
+            InOrder inOrder = Mockito.inOrder(tenantFlyway);
+            inOrder.verify(tenantFlyway).repair();
+            inOrder.verify(tenantFlyway).migrate();
+        }
+    }
+
+    @Test
+    @DisplayName("repair() is NOT called when flywayRepairOnStartup is false")
+    void shouldNotCallRepairWhenDisabled() throws Exception {
+        // Arrange
+        ReflectionTestUtils.setField(service, "flywayRepairOnStartup", false);
+
+        TenantServerConnection tenant = new TenantServerConnection();
+        tenant.setSchemaName("oaf");
+        tenant.setAutoUpdateEnabled(true);
+        when(repository.findAll()).thenReturn(Collections.singletonList(tenant));
+        when(repository.findOneBySchemaName("oaf")).thenReturn(tenant);
+        when(mockStmt.executeUpdate(Mockito.anyString())).thenReturn(1);
+
+        // Act
+        try (MockedConstruction<Flyway> flywayMock = Mockito.mockConstruction(Flyway.class, (mock, ctx) ->
+            when(mock.migrate()).thenReturn(0)
+        )) {
+            service.setupEnvironment();
+
+            Flyway tenantFw = flywayMock.constructed().get(1);
+            verify(tenantFw, never()).repair();
+            verify(tenantFw, times(1)).migrate();
+        }
+    }
+
+    @Test
+    @DisplayName("repair() is NOT called for the core/default schema Flyway migration")
+    void shouldNotCallRepairForDefaultSchema() throws Exception {
+        // Arrange
+        TenantServerConnection tenant = new TenantServerConnection();
+        tenant.setSchemaName("oaf");
+        tenant.setAutoUpdateEnabled(true);
+        when(repository.findAll()).thenReturn(Collections.singletonList(tenant));
+        when(repository.findOneBySchemaName("oaf")).thenReturn(tenant);
+        when(mockStmt.executeUpdate(Mockito.anyString())).thenReturn(1);
+
+        // Act
+        try (MockedConstruction<Flyway> flywayMock = Mockito.mockConstruction(Flyway.class, (mock, ctx) ->
+            when(mock.migrate()).thenReturn(0)
+        )) {
+            service.setupEnvironment();
+
+            Flyway coreFlyway = flywayMock.constructed().get(0);
+            verify(coreFlyway, never()).repair();
+            verify(coreFlyway, times(1)).migrate();
+        }
+    }
+}

--- a/src/test/java/org/apache/fineract/test/PermissionDataTest.java
+++ b/src/test/java/org/apache/fineract/test/PermissionDataTest.java
@@ -1,0 +1,99 @@
+package org.apache.fineract.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.fineract.organisation.permission.PermissionData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PermissionData}, including the {@code @JsonProperty("grouping")}
+ * annotation that preserves API backward compatibility after the DB column rename
+ * from {@code grouping} to {@code module}.
+ */
+class PermissionDataTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("JSON serialization outputs 'grouping' (not 'module') for backward compatibility")
+    @Test
+    void testJsonSerializationUsesGroupingKey() throws Exception {
+        PermissionData data = new PermissionData("authorisation", "READ_USER", "USER", "READ", true);
+
+        String json = objectMapper.writeValueAsString(data);
+
+        assertTrue(json.contains("\"grouping\""), "JSON must contain 'grouping' key for API compatibility");
+        assertFalse(json.contains("\"module\""), "JSON must NOT contain 'module' key — internal field name should not leak to API");
+        assertTrue(json.contains("\"authorisation\""));
+    }
+
+    @DisplayName("JSON deserialization accepts 'grouping' key and maps to module field")
+    @Test
+    void testJsonDeserializationAcceptsGroupingKey() throws Exception {
+        String json = "{\"grouping\":\"transfers\",\"code\":\"READ_TRANSFER\",\"entityName\":\"TRANSFER\",\"actionName\":\"READ\",\"selected\":true}";
+
+        PermissionData data = objectMapper.readValue(json, PermissionData.class);
+
+        assertEquals("transfers", data.getModule());
+        assertEquals("READ_TRANSFER", data.getCode());
+        assertEquals("TRANSFER", data.getEntityName());
+        assertEquals("READ", data.getActionName());
+        assertTrue(data.getSelected());
+    }
+
+    @DisplayName("Constructor sets all fields correctly")
+    @Test
+    void testConstructor() {
+        PermissionData data = new PermissionData("authorisation", "CREATE_USER", "USER", "CREATE", false);
+
+        assertEquals("authorisation", data.getModule());
+        assertEquals("CREATE_USER", data.getCode());
+        assertEquals("USER", data.getEntityName());
+        assertEquals("CREATE", data.getActionName());
+        assertFalse(data.getSelected());
+    }
+
+    @DisplayName("from() factory sets code and selected, others null")
+    @Test
+    void testFromFactory() {
+        PermissionData data = PermissionData.from("READ_TRANSFER", true);
+
+        assertNull(data.getModule());
+        assertEquals("READ_TRANSFER", data.getCode());
+        assertNull(data.getEntityName());
+        assertNull(data.getActionName());
+        assertTrue(data.getSelected());
+    }
+
+    @DisplayName("instance() factory creates PermissionData correctly")
+    @Test
+    void testInstanceFactory() {
+        PermissionData data = PermissionData.instance("operations", "REFUND", "TRANSFER", "REFUND", false);
+
+        assertEquals("operations", data.getModule());
+        assertEquals("REFUND", data.getCode());
+        assertEquals("TRANSFER", data.getEntityName());
+        assertEquals("REFUND", data.getActionName());
+        assertFalse(data.getSelected());
+    }
+
+    @DisplayName("Setters update fields correctly")
+    @Test
+    void testSetters() {
+        PermissionData data = new PermissionData();
+
+        data.setModule("authorisation");
+        data.setCode("UPDATE_ROLE");
+        data.setEntityName("ROLE");
+        data.setActionName("UPDATE");
+        data.setSelected(true);
+
+        assertEquals("authorisation", data.getModule());
+        assertEquals("UPDATE_ROLE", data.getCode());
+        assertEquals("ROLE", data.getEntityName());
+        assertEquals("UPDATE", data.getActionName());
+        assertTrue(data.getSelected());
+    }
+}
+

--- a/src/test/java/org/apache/fineract/test/PermissionEntityTest.java
+++ b/src/test/java/org/apache/fineract/test/PermissionEntityTest.java
@@ -1,0 +1,112 @@
+package org.apache.fineract.test;
+
+import org.apache.fineract.organisation.permission.Permission;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.persistence.Column;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the Permission entity changes related to MySQL 8.0 compatibility.
+ * <p>
+ * MySQL 8.0 made {@code GROUPING} a reserved keyword, so the JPA {@code @Column}
+ * annotation must use backtick-escaped column name ({@code `grouping`}) to generate
+ * valid SQL on both MySQL 5.7 and 8.0.
+ */
+class PermissionEntityTest {
+
+    @DisplayName("grouping field @Column name must be backtick-escaped for MySQL 8.0 reserved keyword")
+    @Test
+    void testGroupingColumnNameIsBacktickEscaped() throws NoSuchFieldException {
+        // Arrange
+        Field groupingField = Permission.class.getDeclaredField("grouping");
+        Column columnAnnotation = groupingField.getAnnotation(Column.class);
+
+        // Assert
+        assertNotNull(columnAnnotation, "@Column annotation must be present on 'grouping' field");
+        assertEquals("`grouping`", columnAnnotation.name(),
+                "Column name must be backtick-escaped because 'grouping' is a reserved keyword in MySQL 8.0");
+    }
+
+    @DisplayName("grouping field @Column must be non-nullable with max length 45")
+    @Test
+    void testGroupingColumnConstraints() throws NoSuchFieldException {
+        // Arrange
+        Field groupingField = Permission.class.getDeclaredField("grouping");
+        Column columnAnnotation = groupingField.getAnnotation(Column.class);
+
+        // Assert
+        assertNotNull(columnAnnotation);
+        assertFalse(columnAnnotation.nullable(), "grouping column must be non-nullable");
+        assertEquals(45, columnAnnotation.length(), "grouping column length must be 45");
+    }
+
+    @DisplayName("grouping getter and setter work correctly")
+    @Test
+    void testGroupingGetterSetter() {
+        // Arrange
+        Permission permission = new Permission();
+
+        // Act
+        permission.setGrouping("authorisation");
+
+        // Assert
+        assertEquals("authorisation", permission.getGrouping());
+    }
+
+    @DisplayName("Permission entity can be fully constructed with grouping field")
+    @Test
+    void testPermissionEntityWithGrouping() {
+        // Arrange
+        Permission permission = new Permission();
+        permission.setGrouping("special");
+        permission.setCode("READ_TRANSFER");
+        permission.setEntityName("TRANSFER");
+        permission.setActionName("READ");
+        permission.setCanMakerChecker(false);
+
+        // Assert
+        assertEquals("special", permission.getGrouping());
+        assertEquals("READ_TRANSFER", permission.getCode());
+        assertEquals("TRANSFER", permission.getEntityName());
+        assertEquals("READ", permission.getActionName());
+        assertFalse(permission.isCanMakerChecker());
+    }
+
+    @DisplayName("hasCode is case-insensitive")
+    @Test
+    void testHasCodeIsCaseInsensitive() {
+        Permission permission = new Permission();
+        permission.setCode("READ_TRANSFER");
+
+        assertTrue(permission.hasCode("read_transfer"));
+        assertTrue(permission.hasCode("READ_TRANSFER"));
+        assertTrue(permission.hasCode("Read_Transfer"));
+    }
+
+    @DisplayName("Non-reserved-keyword columns do not have backtick escaping")
+    @Test
+    void testOtherColumnsNotBacktickEscaped() throws NoSuchFieldException {
+        // Verify that only 'grouping' is backtick-escaped, not other columns
+        Field codeField = Permission.class.getDeclaredField("code");
+        Column codeColumn = codeField.getAnnotation(Column.class);
+        assertNotNull(codeColumn);
+        assertEquals("code", codeColumn.name(), "Non-reserved column 'code' should not be backtick-escaped");
+
+        Field entityNameField = Permission.class.getDeclaredField("entityName");
+        Column entityNameColumn = entityNameField.getAnnotation(Column.class);
+        assertNotNull(entityNameColumn);
+        assertEquals("entity_name", entityNameColumn.name(), "Non-reserved column 'entity_name' should not be backtick-escaped");
+
+        Field actionNameField = Permission.class.getDeclaredField("actionName");
+        Column actionNameColumn = actionNameField.getAnnotation(Column.class);
+        assertNotNull(actionNameColumn);
+        assertEquals("action_name", actionNameColumn.name(), "Non-reserved column 'action_name' should not be backtick-escaped");
+    }
+}

--- a/src/test/java/org/apache/fineract/test/PermissionEntityTest.java
+++ b/src/test/java/org/apache/fineract/test/PermissionEntityTest.java
@@ -15,64 +15,52 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for the Permission entity changes related to MySQL 8.0 compatibility.
  * <p>
- * MySQL 8.0 made {@code GROUPING} a reserved keyword, so the JPA {@code @Column}
- * annotation must use backtick-escaped column name ({@code `grouping`}) to generate
- * valid SQL on both MySQL 5.7 and 8.0.
+ * MySQL 8.0 made {@code GROUPING} a reserved keyword, so the column was renamed
+ * from {@code grouping} to {@code module} to avoid conflicts.
  */
 class PermissionEntityTest {
 
-    @DisplayName("grouping field @Column name must be backtick-escaped for MySQL 8.0 reserved keyword")
+    @DisplayName("module field @Column name must map to 'module' for MySQL 8.0 compatibility")
     @Test
-    void testGroupingColumnNameIsBacktickEscaped() throws NoSuchFieldException {
-        // Arrange
-        Field groupingField = Permission.class.getDeclaredField("grouping");
-        Column columnAnnotation = groupingField.getAnnotation(Column.class);
+    void testModuleColumnName() throws NoSuchFieldException {
+        Field moduleField = Permission.class.getDeclaredField("module");
+        Column columnAnnotation = moduleField.getAnnotation(Column.class);
 
-        // Assert
-        assertNotNull(columnAnnotation, "@Column annotation must be present on 'grouping' field");
-        assertEquals("`grouping`", columnAnnotation.name(),
-                "Column name must be backtick-escaped because 'grouping' is a reserved keyword in MySQL 8.0");
+        assertNotNull(columnAnnotation, "@Column annotation must be present on 'module' field");
+        assertEquals("module", columnAnnotation.name(),
+                "Column name must be 'module' (renamed from 'grouping' which is a reserved keyword in MySQL 8.0)");
     }
 
-    @DisplayName("grouping field @Column must be non-nullable with max length 45")
+    @DisplayName("module field @Column must be non-nullable with max length 45")
     @Test
-    void testGroupingColumnConstraints() throws NoSuchFieldException {
-        // Arrange
-        Field groupingField = Permission.class.getDeclaredField("grouping");
-        Column columnAnnotation = groupingField.getAnnotation(Column.class);
+    void testModuleColumnConstraints() throws NoSuchFieldException {
+        Field moduleField = Permission.class.getDeclaredField("module");
+        Column columnAnnotation = moduleField.getAnnotation(Column.class);
 
-        // Assert
         assertNotNull(columnAnnotation);
-        assertFalse(columnAnnotation.nullable(), "grouping column must be non-nullable");
-        assertEquals(45, columnAnnotation.length(), "grouping column length must be 45");
+        assertFalse(columnAnnotation.nullable(), "module column must be non-nullable");
+        assertEquals(45, columnAnnotation.length(), "module column length must be 45");
     }
 
-    @DisplayName("grouping getter and setter work correctly")
+    @DisplayName("module getter and setter work correctly")
     @Test
-    void testGroupingGetterSetter() {
-        // Arrange
+    void testModuleGetterSetter() {
         Permission permission = new Permission();
-
-        // Act
-        permission.setGrouping("authorisation");
-
-        // Assert
-        assertEquals("authorisation", permission.getGrouping());
+        permission.setModule("authorisation");
+        assertEquals("authorisation", permission.getModule());
     }
 
-    @DisplayName("Permission entity can be fully constructed with grouping field")
+    @DisplayName("Permission entity can be fully constructed with module field")
     @Test
-    void testPermissionEntityWithGrouping() {
-        // Arrange
+    void testPermissionEntityWithModule() {
         Permission permission = new Permission();
-        permission.setGrouping("special");
+        permission.setModule("special");
         permission.setCode("READ_TRANSFER");
         permission.setEntityName("TRANSFER");
         permission.setActionName("READ");
         permission.setCanMakerChecker(false);
 
-        // Assert
-        assertEquals("special", permission.getGrouping());
+        assertEquals("special", permission.getModule());
         assertEquals("READ_TRANSFER", permission.getCode());
         assertEquals("TRANSFER", permission.getEntityName());
         assertEquals("READ", permission.getActionName());
@@ -90,23 +78,22 @@ class PermissionEntityTest {
         assertTrue(permission.hasCode("Read_Transfer"));
     }
 
-    @DisplayName("Non-reserved-keyword columns do not have backtick escaping")
+    @DisplayName("Non-reserved-keyword columns are named normally")
     @Test
     void testOtherColumnsNotBacktickEscaped() throws NoSuchFieldException {
-        // Verify that only 'grouping' is backtick-escaped, not other columns
         Field codeField = Permission.class.getDeclaredField("code");
         Column codeColumn = codeField.getAnnotation(Column.class);
         assertNotNull(codeColumn);
-        assertEquals("code", codeColumn.name(), "Non-reserved column 'code' should not be backtick-escaped");
+        assertEquals("code", codeColumn.name());
 
         Field entityNameField = Permission.class.getDeclaredField("entityName");
         Column entityNameColumn = entityNameField.getAnnotation(Column.class);
         assertNotNull(entityNameColumn);
-        assertEquals("entity_name", entityNameColumn.name(), "Non-reserved column 'entity_name' should not be backtick-escaped");
+        assertEquals("entity_name", entityNameColumn.name());
 
         Field actionNameField = Permission.class.getDeclaredField("actionName");
         Column actionNameColumn = actionNameField.getAnnotation(Column.class);
         assertNotNull(actionNameColumn);
-        assertEquals("action_name", actionNameColumn.name(), "Non-reserved column 'action_name' should not be backtick-escaped");
+        assertEquals("action_name", actionNameColumn.name());
     }
 }

--- a/src/test/java/org/apache/fineract/test/TenantDatabaseUpgradeServiceTest.java
+++ b/src/test/java/org/apache/fineract/test/TenantDatabaseUpgradeServiceTest.java
@@ -34,6 +34,7 @@ class TenantDatabaseUpgradeServiceTest {
         ReflectionTestUtils.setField(service, "username", "user");
         ReflectionTestUtils.setField(service, "password", "pass");
         ReflectionTestUtils.setField(service, "tenants", Collections.singletonList("tenant1"));
+        ReflectionTestUtils.setField(service, "flywayRepairOnStartup", false);
 
         when(mockConn.createStatement()).thenReturn(mockStmt);
         Mockito.doReturn(mockConn)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded MySQL to 8.0; resolved compatibility with reserved keywords and converted tables to utf8mb4.
  * Made tenant migration inserts idempotent to avoid duplicate seed data.

* **Configuration**
  * Added optional startup DB repair toggle (default: off) and raised root log verbosity to INFO.

* **Refactor**
  * Renamed permission categorization from "grouping" to "module" across APIs and data mappings.

* **Documentation**
  * Added release notes for Version 1.1.13.

* **Tests**
  * Added tests for migration sequencing and permission metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->