### PR TITLE
CP-3898 - Sync country roles across tenants

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ Release Notes
             * [CP-4069] - Improvement on update user and role
         * Database
             * [CP-4035] - Upgrade to MySQL 8.0 and address incompatibility issues with MySQL 5.7
+            * [CP-3898] - Sync country roles across tenants
 
 ## Version 1.1.12 - Up to date with Mifos Version 1.5.0
     * Payment Hub OPs

--- a/src/main/resources/sql/migrations/tenant/V50__insert_roles_and_permissions.sql
+++ b/src/main/resources/sql/migrations/tenant/V50__insert_roles_and_permissions.sql
@@ -19,35 +19,35 @@ FROM (SELECT 'super_user'                                      AS name,
              0,
              CAST(DATE (NOW()) AS DATETIME),
              CAST(DATE (NOW()) AS DATETIME),
-             'caroline.kamondia@oneacrefund.org'
+             'migration'
       UNION ALL
       SELECT 'global_cdm',
              'Role to be assigned to global CDM teams',
              0,
              CAST(DATE (NOW()) AS DATETIME),
              CAST(DATE (NOW()) AS DATETIME),
-             'caroline.kamondia@oneacrefund.org'
+             'migration'
       UNION ALL
       SELECT 'country_cdm',
              'Role to be assigned to the back office biz ops team',
              0,
              CAST(DATE (NOW()) AS DATETIME),
              CAST(DATE (NOW()) AS DATETIME),
-             'caroline.kamondia@oneacrefund.org'
+             'migration'
       UNION ALL
       SELECT 'ce_agent',
              'Role to be assigned to country customer experience team',
              0,
              CAST(DATE (NOW()) AS DATETIME),
              CAST(DATE (NOW()) AS DATETIME),
-             'caroline.kamondia@oneacrefund.org'
+             'migration'
       UNION ALL
       SELECT 'audit_user',
              'Role to be assigned to country audit user.',
              0,
              CAST(DATE (NOW()) AS DATETIME),
              CAST(DATE (NOW()) AS DATETIME),
-             'caroline.kamondia@oneacrefund.org') AS new_roles
+             'migration') AS new_roles
 WHERE NOT EXISTS (SELECT 1
                   FROM m_role
                   WHERE name = new_roles.name);

--- a/src/main/resources/sql/migrations/tenant/V50__insert_roles_and_permissions.sql
+++ b/src/main/resources/sql/migrations/tenant/V50__insert_roles_and_permissions.sql
@@ -1,0 +1,72 @@
+-- Flyway Migration Script
+-- Description: Insert initial roles, update Super user name, and assign permissions
+
+-- Step 1: Update 'Super user' to 'super_user' if it exists
+UPDATE m_role SET name = 'super_user' WHERE name = 'Super user';
+
+-- Step 2: Insert roles if they do not already exist
+INSERT INTO m_role (name, description, is_disabled, created_date, last_modified_date, created_by)
+SELECT name, description, is_disabled, created_date, last_modified_date, created_by
+FROM (SELECT 'super_user'                                      AS name,
+             'This role provides all application permissions.' AS description,
+             0                                                 AS is_disabled,
+             NULL                                              AS created_date,
+             NULL                                              AS last_modified_date,
+             NULL                                              AS created_by
+      UNION ALL
+      SELECT 'tech_admin',
+             'Role to be assigned to the Tech Admin',
+             0,
+             CAST(DATE (NOW()) AS DATETIME),
+             CAST(DATE (NOW()) AS DATETIME),
+             'caroline.kamondia@oneacrefund.org'
+      UNION ALL
+      SELECT 'global_cdm',
+             'Role to be assigned to global CDM teams',
+             0,
+             CAST(DATE (NOW()) AS DATETIME),
+             CAST(DATE (NOW()) AS DATETIME),
+             'caroline.kamondia@oneacrefund.org'
+      UNION ALL
+      SELECT 'country_cdm',
+             'Role to be assigned to the back office biz ops team',
+             0,
+             CAST(DATE (NOW()) AS DATETIME),
+             CAST(DATE (NOW()) AS DATETIME),
+             'caroline.kamondia@oneacrefund.org'
+      UNION ALL
+      SELECT 'ce_agent',
+             'Role to be assigned to country customer experience team',
+             0,
+             CAST(DATE (NOW()) AS DATETIME),
+             CAST(DATE (NOW()) AS DATETIME),
+             'caroline.kamondia@oneacrefund.org'
+      UNION ALL
+      SELECT 'audit_user',
+             'Role to be assigned to country audit user.',
+             0,
+             CAST(DATE (NOW()) AS DATETIME),
+             CAST(DATE (NOW()) AS DATETIME),
+             'caroline.kamondia@oneacrefund.org') AS new_roles
+WHERE NOT EXISTS (SELECT 1
+                  FROM m_role
+                  WHERE name = new_roles.name);
+
+-- Step 3: Insert role-permission mappings, ignoring duplicates
+INSERT IGNORE INTO m_role_permission (role_id, permission_id)
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'audit_user'  AND p.code = 'EXPORT_TRANSACTION_REQUEST' UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'audit_user'  AND p.code = 'EXPORT_TRANSFER'            UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'audit_user'  AND p.code = 'READ_AUDIT'                 UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'audit_user'  AND p.code = 'READ_TRANSACTION_REQUEST'   UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'audit_user'  AND p.code = 'READ_TRANSFER'              UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'ce_agent'    AND p.code = 'READ_TRANSACTION_REQUEST'   UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'ce_agent'    AND p.code = 'READ_TRANSFER'              UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'country_cdm' AND p.code = 'EXPORT_TRANSACTION_REQUEST' UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'country_cdm' AND p.code = 'EXPORT_TRANSFER'            UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'country_cdm' AND p.code = 'READ_TRANSACTION_REQUEST'   UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'country_cdm' AND p.code = 'READ_TRANSFER'              UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'global_cdm'  AND p.code = 'READ_TRANSACTION_REQUEST'   UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'global_cdm'  AND p.code = 'READ_TRANSFER'              UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'super_user'  AND p.code = 'ALL_FUNCTIONS'              UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'tech_admin'  AND p.code = 'READ_TRANSACTION_REQUEST'   UNION ALL
+SELECT r.id, p.id FROM m_role r JOIN m_permission p ON r.name = 'tech_admin'  AND p.code = 'READ_TRANSFER';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Country roles can be synchronized across tenants for consistent access management.
  * New system roles added: super_user, tech_admin, global_cdm, country_cdm, ce_agent, and audit_user.
  * Predefined role-permission mappings established to improve and standardize access control across the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->